### PR TITLE
Show name of destination player for items in tracker log

### DIFF
--- a/RandomizerMod3.0/GiveItemActions.cs
+++ b/RandomizerMod3.0/GiveItemActions.cs
@@ -72,7 +72,12 @@ namespace RandomizerMod
             {
                 string loc = location;
                 if (remote) loc = $"{from}-{location}";
-                LogItemToTracker(rawItem, loc);
+                string it = item;
+                if (player != RandomizerMod.Instance.Settings.MWPlayerId)
+                {
+                    it = $"{LanguageStringManager.GetMWPlayerName(player)}-{item}";
+                }
+                LogItemToTracker(it, loc);
             }
             else
             {

--- a/RandomizerMod3.0/LanguageStringManager.cs
+++ b/RandomizerMod3.0/LanguageStringManager.cs
@@ -21,7 +21,7 @@ namespace RandomizerMod
         // It's easier to just update this static variable after deserializing than passing settings around since LanguageStringManager
         // is mostly used while creating randomizer actions and the settings won't be copied into RandomizerMod yet
         private static Dictionary<int, string> MWNicknames = new Dictionary<int, string>();
-        private static string GetMWPlayerName(int playerId)
+        public static string GetMWPlayerName(int playerId)
         {
             string name = "Player " + (playerId + 1);
             if (MWNicknames != null && MWNicknames.ContainsKey(playerId))


### PR DESCRIPTION
Currently it only shows the source player's name for the location,
the item itself only has their numeric ID, which is inconsistent
(and not very helpful).