### PR TITLE
Serecore update

### DIFF
--- a/MWRandomizerTest/FakeClient.csproj
+++ b/MWRandomizerTest/FakeClient.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/MultiWorldProtocol/MultiWorldProtocol.csproj
+++ b/MultiWorldProtocol/MultiWorldProtocol.csproj
@@ -17,10 +17,10 @@
 
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/MultiWorldServer/MultiWorldServer.csproj
+++ b/MultiWorldServer/MultiWorldServer.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ This mod is an extension of the existing Randomizer3.0 and MultiWorld mods to al
 - Concurrent sessions - Once a randomization is generated, a random identifier is included with it which is used to spin up a new session when connecting to the server. This way, multiple concurrent rando sessions can run simultaneously on the same server
 
 ## Getting Started
-1. Install SeanprCore and modding API if you haven't already (this can be done through the mod installer: https://www.nexusmods.com/hollowknight/mods/9)
+1. Install the Modding API, Serecore, QoL, Vasi and Benchwarp if you haven't already (this can be done through the mod installer: https://www.nexusmods.com/hollowknight/mods/9)
 2. Download `RandomizerModMW.zip` from the releases page on github: https://github.com/CallumMoseley/HollowKnight.RandomizerMod/releases
 3. Copy `MultiWorldProtocol.dll`, `RandomizerLib3.0.dll`, and `RandomizerMod3.0.dll` into `Hollow Knight/hollow_knight_Data/Managed/Mods` (this will replace the existing RandomizerMod3.0 if you have it installed)
+4. Note: if you run ModInstaller after this, it will tell you Randomizer is outdated and ask you to update. Select no, as this will replace multiworld randomizer with the main version.
 
 This is all that is needed in terms of setup. To play multiworld:
 

--- a/RandomizerLib3.0/LogicManager.cs
+++ b/RandomizerLib3.0/LogicManager.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
-using SeanprCore;
+using SereCore;
 using static RandomizerLib.Logging.LogHelper;
 using System.Text.RegularExpressions;
 using GlobalEnums;

--- a/RandomizerLib3.0/RandomizerLib3.0.csproj
+++ b/RandomizerLib3.0/RandomizerLib3.0.csproj
@@ -33,13 +33,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\PlayMaker.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\PlayMaker.dll</HintPath>
     </Reference>
-    <Reference Include="SeanprCore">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\SeanprCore.dll</HintPath>
+    <Reference Include="SereCore">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\SereCore.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/RandomizerMod3.0/Actions/AddShinyToChest.cs
+++ b/RandomizerMod3.0/Actions/AddShinyToChest.cs
@@ -1,6 +1,6 @@
 ﻿using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 
 namespace RandomizerMod.Actions

--- a/RandomizerMod3.0/Actions/AddYNDialogueToShiny.cs
+++ b/RandomizerMod3.0/Actions/AddYNDialogueToShiny.cs
@@ -6,7 +6,7 @@ using Modding;
 using UnityEngine.SceneManagement;
 using RandomizerMod.Extensions;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using static RandomizerMod.LogHelper;
 

--- a/RandomizerMod3.0/Actions/ChangeBoolTest.cs
+++ b/RandomizerMod3.0/Actions/ChangeBoolTest.cs
@@ -1,7 +1,7 @@
 ﻿using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using System;
 using Object = UnityEngine.Object;

--- a/RandomizerMod3.0/Actions/ChangeChestGeo.cs
+++ b/RandomizerMod3.0/Actions/ChangeChestGeo.cs
@@ -1,7 +1,7 @@
 ﻿using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 
 using RandomizerLib;

--- a/RandomizerMod3.0/Actions/ChangeShinyIntoBigItem.cs
+++ b/RandomizerMod3.0/Actions/ChangeShinyIntoBigItem.cs
@@ -2,7 +2,7 @@
 using HutongGames.PlayMaker.Actions;
 using RandomizerMod.Components;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using static RandomizerMod.GiveItemActions;
 using System.Collections;

--- a/RandomizerMod3.0/Actions/ChangeShinyIntoGeo.cs
+++ b/RandomizerMod3.0/Actions/ChangeShinyIntoGeo.cs
@@ -1,7 +1,7 @@
 ﻿using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 
 using RandomizerLib;

--- a/RandomizerMod3.0/Actions/ChangeShinyIntoItem.cs
+++ b/RandomizerMod3.0/Actions/ChangeShinyIntoItem.cs
@@ -4,7 +4,7 @@ using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
 using RandomizerMod.FsmStateActions;
 using RandomizerMod.Extensions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using static RandomizerMod.GiveItemActions;
 

--- a/RandomizerMod3.0/Actions/ChangeShinyIntoLifeblood.cs
+++ b/RandomizerMod3.0/Actions/ChangeShinyIntoLifeblood.cs
@@ -1,7 +1,7 @@
 ﻿using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 
 using RandomizerLib;

--- a/RandomizerMod3.0/Actions/ChangeShinyIntoSoul.cs
+++ b/RandomizerMod3.0/Actions/ChangeShinyIntoSoul.cs
@@ -1,7 +1,7 @@
 ﻿using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using static RandomizerMod.LogHelper;
 

--- a/RandomizerMod3.0/Actions/CreateNewShiny.cs
+++ b/RandomizerMod3.0/Actions/CreateNewShiny.cs
@@ -1,6 +1,6 @@
 ﻿using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 
 namespace RandomizerMod.Actions

--- a/RandomizerMod3.0/Actions/RandomizerAction.cs
+++ b/RandomizerMod3.0/Actions/RandomizerAction.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using RandomizerMod.Randomization;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using static RandomizerMod.LogHelper;
 using static RandomizerMod.GiveItemActions;

--- a/RandomizerMod3.0/Actions/ReplaceObjectWithShiny.cs
+++ b/RandomizerMod3.0/Actions/ReplaceObjectWithShiny.cs
@@ -1,6 +1,6 @@
 ﻿using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 

--- a/RandomizerMod3.0/BenchHandler.cs
+++ b/RandomizerMod3.0/BenchHandler.cs
@@ -1,5 +1,5 @@
 ﻿using On.HutongGames.PlayMaker.Actions;
-using SeanprCore;
+using SereCore;
 
 namespace RandomizerMod
 {

--- a/RandomizerMod3.0/Components/BigItemPopup.cs
+++ b/RandomizerMod3.0/Components/BigItemPopup.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
 using Modding;
 using RandomizerMod.Actions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.UI;
 using System.Linq;

--- a/RandomizerMod3.0/Components/RandomizerTinkEffect.cs
+++ b/RandomizerMod3.0/Components/RandomizerTinkEffect.cs
@@ -1,4 +1,4 @@
-﻿using SeanprCore;
+﻿using SereCore;
 using UnityEngine;
 using Random = System.Random;
 

--- a/RandomizerMod3.0/Components/Shop.cs
+++ b/RandomizerMod3.0/Components/Shop.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Modding;
 using RandomizerMod.Actions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.UI;
 using static RandomizerMod.LogHelper;

--- a/RandomizerMod3.0/Components/StickyWall.cs
+++ b/RandomizerMod3.0/Components/StickyWall.cs
@@ -4,7 +4,7 @@ using GlobalEnums;
 using Modding;
 using MonoMod.Utils;
 using RandomizerMod.Extensions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 
 // ReSharper disable file UnusedMember.Global

--- a/RandomizerMod3.0/FsmStateActions/RandomizerAddGeo.cs
+++ b/RandomizerMod3.0/FsmStateActions/RandomizerAddGeo.cs
@@ -1,5 +1,5 @@
 ﻿using HutongGames.PlayMaker;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using Random = System.Random;
 

--- a/RandomizerMod3.0/FsmStateActions/RandomizerAddSoul.cs
+++ b/RandomizerMod3.0/FsmStateActions/RandomizerAddSoul.cs
@@ -1,5 +1,5 @@
-using HutongGames.PlayMaker;
-using SeanprCore;
+﻿using HutongGames.PlayMaker;
+using SereCore;
 using UnityEngine;
 using Random = System.Random;
 using static RandomizerMod.LogHelper;

--- a/RandomizerMod3.0/FsmStateActions/RandomizerBoolTest.cs
+++ b/RandomizerMod3.0/FsmStateActions/RandomizerBoolTest.cs
@@ -1,5 +1,5 @@
 ﻿using HutongGames.PlayMaker;
-using SeanprCore;
+using SereCore;
 
 namespace RandomizerMod.FsmStateActions
 {

--- a/RandomizerMod3.0/FsmStateActions/RandomizerChangeScene.cs
+++ b/RandomizerMod3.0/FsmStateActions/RandomizerChangeScene.cs
@@ -1,7 +1,7 @@
 ﻿using GlobalEnums;
 using HutongGames.PlayMaker;
 using Modding;
-using SeanprCore;
+using SereCore;
 
 namespace RandomizerMod.FsmStateActions
 {

--- a/RandomizerMod3.0/FsmStateActions/RandomizerSetBool.cs
+++ b/RandomizerMod3.0/FsmStateActions/RandomizerSetBool.cs
@@ -1,5 +1,5 @@
 ﻿using HutongGames.PlayMaker;
-using SeanprCore;
+using SereCore;
 
 namespace RandomizerMod.FsmStateActions
 {

--- a/RandomizerMod3.0/FsmStateActions/RandomizerSetHardSave.cs
+++ b/RandomizerMod3.0/FsmStateActions/RandomizerSetHardSave.cs
@@ -1,5 +1,5 @@
 ﻿using HutongGames.PlayMaker;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using static RandomizerMod.LogHelper;
 

--- a/RandomizerMod3.0/MenuChanger.cs
+++ b/RandomizerMod3.0/MenuChanger.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using RandomizerMod.Extensions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;

--- a/RandomizerMod3.0/MultiWorld/MWSettings.cs
+++ b/RandomizerMod3.0/MultiWorld/MWSettings.cs
@@ -1,4 +1,4 @@
-﻿using SeanprCore;
+﻿using SereCore;
 
 namespace RandomizerMod.MultiWorld
 {

--- a/RandomizerMod3.0/ObjectCache.cs
+++ b/RandomizerMod3.0/ObjectCache.cs
@@ -2,7 +2,7 @@
 using Modding;
 using UnityEngine;
 using static RandomizerMod.LogHelper;
-using SeanprCore;
+using SereCore;
 using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
 

--- a/RandomizerMod3.0/RandomizerMod.cs
+++ b/RandomizerMod3.0/RandomizerMod.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using Modding;
 using RandomizerMod.Actions;
 using RandomizerMod.Randomization;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using static RandomizerMod.GiveItemActions;

--- a/RandomizerMod3.0/RandomizerMod3.0.csproj
+++ b/RandomizerMod3.0/RandomizerMod3.0.csproj
@@ -32,13 +32,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\PlayMaker.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\PlayMaker.dll</HintPath>
     </Reference>
-    <Reference Include="SeanprCore">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\SeanprCore.dll</HintPath>
+    <Reference Include="SereCore">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\SereCore.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,40 +47,40 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.Physics2DModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/RandomizerMod3.0/RestrictionManager.cs
+++ b/RandomizerMod3.0/RestrictionManager.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using HutongGames.PlayMaker;
 using HutongGames.PlayMaker.Actions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 

--- a/RandomizerMod3.0/SaveSettings.cs
+++ b/RandomizerMod3.0/SaveSettings.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Modding;
 using RandomizerMod.Actions;
-using SeanprCore;
+using SereCore;
 using RandomizerMod.Randomization;
 using static RandomizerMod.LogHelper;
 

--- a/RandomizerMod3.0/SceneChanges/DreamPlantEdits.cs
+++ b/RandomizerMod3.0/SceneChanges/DreamPlantEdits.cs
@@ -8,7 +8,7 @@ using HutongGames.PlayMaker.Actions;
 using Modding;
 using RandomizerMod.Components;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Random = System.Random;

--- a/RandomizerMod3.0/SceneChanges/QoLFixes.cs
+++ b/RandomizerMod3.0/SceneChanges/QoLFixes.cs
@@ -7,7 +7,7 @@ using HutongGames.PlayMaker.Actions;
 using Modding;
 using RandomizerMod.Components;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Random = System.Random;

--- a/RandomizerMod3.0/SceneChanges/RandomizerChanges.cs
+++ b/RandomizerMod3.0/SceneChanges/RandomizerChanges.cs
@@ -7,7 +7,7 @@ using HutongGames.PlayMaker.Actions;
 using Modding;
 using RandomizerMod.Components;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Random = System.Random;

--- a/RandomizerMod3.0/SceneChanges/SceneEditor.cs
+++ b/RandomizerMod3.0/SceneChanges/SceneEditor.cs
@@ -7,7 +7,7 @@ using HutongGames.PlayMaker.Actions;
 using Modding;
 using RandomizerMod.Components;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Random = System.Random;

--- a/RandomizerMod3.0/SceneChanges/SkipFixes.cs
+++ b/RandomizerMod3.0/SceneChanges/SkipFixes.cs
@@ -7,7 +7,7 @@ using HutongGames.PlayMaker.Actions;
 using Modding;
 using RandomizerMod.Components;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Random = System.Random;

--- a/RandomizerMod3.0/SceneChanges/TransitionFixes.cs
+++ b/RandomizerMod3.0/SceneChanges/TransitionFixes.cs
@@ -7,7 +7,7 @@ using HutongGames.PlayMaker.Actions;
 using Modding;
 using RandomizerMod.Components;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Random = System.Random;

--- a/RandomizerMod3.0/StartSaveChanges.cs
+++ b/RandomizerMod3.0/StartSaveChanges.cs
@@ -7,7 +7,7 @@ using HutongGames.PlayMaker.Actions;
 using Modding;
 using RandomizerMod.Components;
 using RandomizerMod.FsmStateActions;
-using SeanprCore;
+using SereCore;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Random = System.Random;


### PR DESCRIPTION
Serecore has replaced seanprcore, and using seanprcore will spam modlog with warnings. update to use serecore. also update readme to reflect this, as well as warn against updating through modinstaller and mention Qol, Vasi and Benchwarp as dependencies (these are required).