### PR TITLE
Fixed vanilla shinies not showing up

### DIFF
--- a/MultiWorldServer/Server.cs
+++ b/MultiWorldServer/Server.cs
@@ -120,12 +120,7 @@ namespace MultiWorldServer
             LogToConsole($"{ready.Count} current lobbies");
             foreach (var kvp in ready)
             {
-                string playerString = "";
-                foreach (var key in kvp.Value.Keys)
-                {
-                    playerString += $"{Clients[key].Nickname}, ";
-                }
-                if (playerString != "") playerString = playerString.Substring(0, playerString.Length - 2);
+                string playerString = string.Join(", ", kvp.Value.Keys.Select((uid) => Clients[uid].Nickname).ToArray());
                 LogToConsole($"Room: {kvp.Key} players: {playerString}");
             }
         }
@@ -487,17 +482,7 @@ namespace MultiWorldServer
                 string roomText = string.IsNullOrEmpty(sender.Room) ? "default room" : $"room \"{sender.Room}\"";
                 Log($"{sender.Nickname} (UID {sender.UID}) readied up in {roomText} ({ready[sender.Room].Count} readied)");
 
-                string names = "";
-                foreach (ulong uid in ready[sender.Room].Keys)
-                {
-                    names += Clients[uid].Nickname;
-                    names += ", ";
-                }
-
-                if (names.Length >= 2)
-                {
-                    names = names.Substring(0, names.Length - 2);
-                }
+                string names = string.Join(", ", ready[sender.Room].Keys.Select((uid) => Clients[uid].Nickname).ToArray());
 
                 foreach (ulong uid in ready[sender.Room].Keys)
                 {
@@ -565,7 +550,6 @@ namespace MultiWorldServer
             if (!unsavedResults.ContainsKey(message.ReadyID))
             {
                 Log($"Bad rejoin attempt (readyId = {message.ReadyID}, UID = {sender.UID})");
-                return;
             }
             else
             {

--- a/RandomizerMod3.0/Actions/RandomizerAction.cs
+++ b/RandomizerMod3.0/Actions/RandomizerAction.cs
@@ -34,7 +34,7 @@ namespace RandomizerMod.Actions
         public static void CreateActions((string, string)[] items, SaveSettings settings)
         {
             ClearActions();
-            
+
             ShopItemBoolNames = new Dictionary<(string, string), string>();
             AdditiveBoolNames = new Dictionary<string, string>();
 
@@ -49,32 +49,34 @@ namespace RandomizerMod.Actions
                 ReqDef oldItem = LogicManager.GetItemDef(location);
                 ReqDef newItem = LogicManager.GetItemDef(newItemName);
 
-                // Disable this for multiworld, since we might have items from other people's worlds
-
-                /*if (!settings.RandomizeMaps && newItem.pool == "Map")
+                // In MW, we only want to skip these when they are our own items
+                if (playerId < 0 || playerId == settings.MWPlayerId)
                 {
-                    continue;
+                    if (!settings.RandomizeMaps && newItem.pool == "Map")
+                    {
+                        continue;
+                    }
+                    if (!settings.RandomizeStags && newItem.pool == "Stag")
+                    {
+                        continue;
+                    }
+                    if (!settings.RandomizeRocks && newItem.pool == "Rock")
+                    {
+                        continue;
+                    }
+                    if (!settings.RandomizeSoulTotems && newItem.pool == "Soul")
+                    {
+                        continue;
+                    }
+                    if (!settings.RandomizePalaceTotems && newItem.pool == "PalaceSoul")
+                    {
+                        continue;
+                    }
+                    if (!settings.RandomizeLoreTablets && newItem.pool == "Lore")
+                    {
+                        continue;
+                    }
                 }
-                if (!settings.RandomizeStags && newItem.pool == "Stag") 
-                {
-                    continue;
-                }
-                if (!settings.RandomizeRocks && newItem.pool == "Rock") 
-                {
-                    continue;
-                }
-                if (!settings.RandomizeSoulTotems && newItem.pool == "Soul") 
-                {
-                    continue;
-                }
-                if (!settings.RandomizePalaceTotems && newItem.pool == "PalaceSoul") 
-                {
-                    continue;
-                }
-                if (!settings.RandomizeLoreTablets && newItem.pool == "Lore") 
-                {
-                    continue;
-                }*/
 
                 if (oldItem.replace)
                 {

--- a/RandomizerMod3.0/MenuChanger.cs
+++ b/RandomizerMod3.0/MenuChanger.cs
@@ -404,10 +404,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);
@@ -429,10 +425,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(false);
                         RandoMaskBtn.SetSelection(false);
                         RandoVesselBtn.SetSelection(false);
@@ -454,10 +446,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);
@@ -479,10 +467,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);
@@ -504,10 +488,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);
@@ -529,10 +509,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);
@@ -554,10 +530,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);
@@ -579,10 +551,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);
@@ -604,10 +572,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);
@@ -629,10 +593,6 @@ namespace RandomizerMod
                         DuplicateBtn.SetSelection(true);
                         HandleProgressionLock();
 
-                        RandoDreamersBtn.SetSelection(true);
-                        RandoSkillsBtn.SetSelection(true);
-                        RandoCharmsBtn.SetSelection(true);
-                        RandoKeysBtn.SetSelection(true);
                         RandoGeoChestsBtn.SetSelection(true);
                         RandoMaskBtn.SetSelection(true);
                         RandoVesselBtn.SetSelection(true);

--- a/RandomizerMod3.0/MenuChanger.cs
+++ b/RandomizerMod3.0/MenuChanger.cs
@@ -401,6 +401,9 @@ namespace RandomizerMod
                 switch (item.CurrentSelection)
                 {
                     case "Mini Super Junk Pit":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -423,6 +426,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Basic":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -445,6 +451,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Completionist":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -467,6 +476,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Junk Pit":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -489,6 +501,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Super Junk Pit":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -511,6 +526,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Mini Super Geo Pit":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -533,6 +551,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Super Geo Pit":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -555,6 +576,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Mini Super Totem Pit":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -577,6 +601,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Super Totem Pit":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -599,6 +626,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "EVERYTHING":
+                        DuplicateBtn.SetSelection(true);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(true);
                         RandoSkillsBtn.SetSelection(true);
                         RandoCharmsBtn.SetSelection(true);
@@ -621,6 +651,9 @@ namespace RandomizerMod
                         //RandoLoreTabletsBtn.SetSelection(false);
                         break;
                     case "Vanilla":
+                        DuplicateBtn.SetSelection(false);
+                        HandleProgressionLock();
+
                         RandoDreamersBtn.SetSelection(false);
                         RandoSkillsBtn.SetSelection(false);
                         RandoCharmsBtn.SetSelection(false);

--- a/RandomizerMod3.0/MultiWorld/ClientConnection.cs
+++ b/RandomizerMod3.0/MultiWorld/ClientConnection.cs
@@ -477,10 +477,7 @@ namespace RandomizerMod.MultiWorld
 
         public void NotifySave()
         {
-            if (RandomizerMod.Instance.MWSettings.LastReadyID != -1)
-            {
-                SendMessage(new MWSaveMessage { ReadyID = RandomizerMod.Instance.MWSettings.LastReadyID });
-            }
+            SendMessage(new MWSaveMessage { ReadyID = RandomizerMod.Instance.MWSettings.LastReadyID });
             RandomizerMod.Instance.MWSettings.LastReadyID = -1;
         }
 

--- a/RandomizerMod3.0/Randomization/PostRandomizer.cs
+++ b/RandomizerMod3.0/Randomization/PostRandomizer.cs
@@ -35,7 +35,10 @@ namespace RandomizerMod.Randomization
                 spoilerLogger.LogAllToSpoiler(result);
             }
 
-            RandomizerAction.CreateActions(RandomizerMod.Instance.Settings.ItemPlacements, RandomizerMod.Instance.Settings);
+            List<(string, string)> allItemPlacements = VanillaManager.ItemPlacements;
+            allItemPlacements.AddRange(RandomizerMod.Instance.Settings.ItemPlacements);
+            
+            RandomizerAction.CreateActions(allItemPlacements.ToArray(), RandomizerMod.Instance.Settings);
 
             if (RandomizerMod.Instance.Settings.IsMW)
             {


### PR DESCRIPTION
Fix vanilla items to still create shinies when not randomizing dreamers and others.

Also, fix vanilla preset to set duplicates to false.